### PR TITLE
Refactor auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release: check test clean build package
 .PHONY: build
 build:
 	mkdir ${OUTPUT_DIR}
-	CGO_ENABLED=1 GOARM=5 gox -ldflags "-w -X main.version=$(GIT_COMMIT)" \
+	CGO_ENABLED=0 GOARM=5 gox -ldflags "-w -X main.version=$(GIT_COMMIT)" \
 	-os=${OS} -arch=${ARCH} -osarch=${OSARCH} -output "${OUTPUT_DIR}/pkg/{{.OS}}_{{.Arch}}/{{.Dir}}" \
 	./cmd/tunnel ./cmd/tunneld
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release: check test clean build package
 .PHONY: build
 build:
 	mkdir ${OUTPUT_DIR}
-	CGO_ENABLED=0 GOARM=5 gox -ldflags "-w -X main.version=$(GIT_COMMIT)" \
+	CGO_ENABLED=1 GOARM=5 gox -ldflags "-w -X main.version=$(GIT_COMMIT)" \
 	-os=${OS} -arch=${ARCH} -osarch=${OSARCH} -output "${OUTPUT_DIR}/pkg/{{.OS}}_{{.Arch}}/{{.Dir}}" \
 	./cmd/tunnel ./cmd/tunneld
 

--- a/auth.go
+++ b/auth.go
@@ -4,26 +4,24 @@
 
 package tunnel
 
-import "strings"
-
 // Auth holds user and password.
+//type Auth struct {
+//	User     string
+//	Password string
+//}
+
 type Auth struct {
-	User     string
-	Password string
+	Token string
 }
 
 // NewAuth creates new auth from string representation "user:password".
-func NewAuth(auth string) *Auth {
-	if auth == "" {
+func NewAuth(token string) *Auth {
+	if token == "" {
 		return nil
 	}
 
-	s := strings.SplitN(auth, ":", 2)
 	a := &Auth{
-		User: s[0],
-	}
-	if len(s) > 1 {
-		a.Password = s[1]
+		Token: token,
 	}
 
 	return a

--- a/auth.go
+++ b/auth.go
@@ -4,17 +4,11 @@
 
 package tunnel
 
-// Auth holds user and password.
-//type Auth struct {
-//	User     string
-//	Password string
-//}
-
 type Auth struct {
 	Token string
 }
 
-// NewAuth creates new auth from string representation "user:password".
+// NewAuth creates new auth from string.
 func NewAuth(token string) *Auth {
 	if token == "" {
 		return nil

--- a/auth_test.go
+++ b/auth_test.go
@@ -15,9 +15,7 @@ func TestNewAuth(t *testing.T) {
 		expected *Auth
 	}{
 		{"", nil},
-		{"user", &Auth{User: "user"}},
-		{"user:password", &Auth{User: "user", Password: "password"}},
-		{"user:pass:word", &Auth{User: "user", Password: "pass:word"}},
+		{"token", &Auth{Token: "token"}},
 	}
 
 	for _, tt := range tests {

--- a/client.go
+++ b/client.go
@@ -40,6 +40,8 @@ type ClientConfig struct {
 	Proxy ProxyFunc
 	// Logger is optional logger. If nil logging is disabled.
 	Logger log.Logger
+	// Auth token
+	AuthToken string
 }
 
 // Client is responsible for creating connection to the server, handling control
@@ -295,6 +297,7 @@ func (c *Client) handleHandshake(w http.ResponseWriter, r *http.Request) {
 		"addr", r.RemoteAddr,
 	)
 
+	w.Header().Add("X-Auth-Header", c.config.AuthToken)
 	w.WriteHeader(http.StatusOK)
 
 	b, err := json.Marshal(c.config.Tunnels)

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -102,6 +102,7 @@ func main() {
 		Tunnels:         tunnels(config.Tunnels),
 		Proxy:           proxy(config.Tunnels, logger),
 		Logger:          logger,
+		AuthToken:       "baba2",
 	})
 	if err != nil {
 		fatal("failed to create client: %s", err)

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -102,7 +102,7 @@ func main() {
 		Tunnels:         tunnels(config.Tunnels),
 		Proxy:           proxy(config.Tunnels, logger),
 		Logger:          logger,
-		AuthToken:       "baba2",
+		AuthToken:       "auth-token",
 	})
 	if err != nil {
 		fatal("failed to create client: %s", err)

--- a/cmd/tunneld/tunneld.go
+++ b/cmd/tunneld/tunneld.go
@@ -46,6 +46,9 @@ func main() {
 		AutoSubscribe: autoSubscribe,
 		TLSConfig:     tlsconf,
 		Logger:        logger,
+		AuthHandler: func(s string) bool {
+			return s == "baba1"
+		},
 	})
 	if err != nil {
 		fatal("failed to create server: %s", err)

--- a/cmd/tunneld/tunneld.go
+++ b/cmd/tunneld/tunneld.go
@@ -47,7 +47,7 @@ func main() {
 		TLSConfig:     tlsconf,
 		Logger:        logger,
 		AuthHandler: func(s string) bool {
-			return s == "baba1"
+			return s == "auth-token"
 		},
 	})
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -120,7 +120,7 @@ func makeTunnelClient(t testing.TB, serverAddr string, httpLocalAddr, httpAddr, 
 		proto.HTTP: {
 			Protocol: proto.HTTP,
 			Host:     "localhost",
-			Auth:     "user:password",
+			Auth:     "test-token",
 		},
 		proto.TCP: {
 			Protocol: proto.TCP,
@@ -212,7 +212,7 @@ func testHTTP(t testing.TB, addr net.Addr, payload []byte, repeat uint) {
 		if err != nil {
 			t.Fatal("Failed to create request")
 		}
-		r.SetBasicAuth("user", "password")
+		r.Header.Set("X-Auth-Header", "test-token")
 
 		resp, err := http.DefaultClient.Do(r)
 		if err != nil {

--- a/registry.go
+++ b/registry.go
@@ -138,8 +138,8 @@ func (r *registry) set(i *RegistryItem, identifier id.ID) error {
 
 	if i.Hosts != nil {
 		for _, h := range i.Hosts {
-			if h.Auth != nil && h.Auth.User == "" {
-				return fmt.Errorf("missing auth user")
+			if h.Auth != nil && h.Auth.Token == "" {
+				return fmt.Errorf("missing auth token")
 			}
 			if _, ok := r.hosts[trimPort(h.Host)]; ok {
 				return fmt.Errorf("host %q is occupied", h.Host)


### PR DESCRIPTION
Now on the initial handshake, when `server` sends `CONNECT` request, `client` must respond with an auth token inside `X-Auth-Header`. The valid token will authorize the creation of HTTP tunnel.

### Changes
- Expand `ClientConfig` structure with token property and send this token on `CONNECT` request
- Expand `ServerConfig` with function `AuthHandler` that is invoked to validate the token
- Refactor `Auth` structure to reflect token authentication, and minor changes related to change of this structure
- Fix failing tests